### PR TITLE
fix(mutators): disable nested mutators

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,13 +30,20 @@ module.exports = {
 			}
 		  }
 	},
-    plugins: ["unused-imports"],  
+    plugins: ["unused-imports", "@stylistic"],  
     rules: {  
 		"indent": ["error", "tab", { "SwitchCase": 1 }],
         quotes: [2, "double", { avoidEscape: true }],  
         "unused-imports/no-unused-imports": "error",  
         "no-async-promise-executor": "off",  
-        "mocha/no-setup-in-describe": "off",  
+        "mocha/no-setup-in-describe": "off",
+		"@stylistic/object-property-newline": ["error"],
+		"@stylistic/object-curly-newline": ["error", {
+			"ObjectExpression": { "multiline": true, "minProperties": 1 },
+			"ObjectPattern": { "multiline": true, "minProperties": 3 },
+			"ImportDeclaration": { "multiline": true, "minProperties": 3 },
+			"ExportDeclaration": { "multiline": true, "minProperties": 2 }
+		}],
         "@typescript-eslint/no-floating-promises": ["error"],  
         "@typescript-eslint/no-explicit-any": "off",  
         "@typescript-eslint/consistent-type-imports": "error",  

--- a/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/BoardEvolver.ts
+++ b/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/BoardEvolver.ts
@@ -1,7 +1,9 @@
 import { Evolver } from "theseus-js";
 import type { GameState, MarkType } from "../../state/GameState";
 
-export const BoardEvolver = Evolver.create("BoardEvolver", { noun: "gameState" })
+export const BoardEvolver = Evolver.create("BoardEvolver", {
+	noun: "gameState", 
+})
 	.toEvolve<GameState>()
 	.withMutators({
 		/**

--- a/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/MetaEvolver.ts
+++ b/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/MetaEvolver.ts
@@ -1,7 +1,9 @@
 import { Evolver } from "theseus-js";
 import type { GameState, MarkType } from "../../state/GameState";
 
-export const MetaEvolver = Evolver.create("MetaEvolver", { noun: "gameState" })
+export const MetaEvolver = Evolver.create("MetaEvolver", {
+	noun: "gameState", 
+})
 	.toEvolve<GameState>()
 	.withMutators({
 		/**

--- a/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/TurnEvolver.ts
+++ b/.examples/tic-tac-toe/src/game-ship/evolve/evolvers/TurnEvolver.ts
@@ -6,7 +6,9 @@ import { MetaEvolver } from "./MetaEvolver";
 
 const log = getTheseusLogger("GameTurnEvolver");
 
-export const TurnEvolver = Evolver.create("TurnEvolver", { noun: "gameState" })
+export const TurnEvolver = Evolver.create("TurnEvolver", {
+	noun: "gameState", 
+})
 	.toEvolve<GameState>()
 	.withMutators({
 		/**

--- a/.examples/tic-tac-toe/src/game-ship/refine/refineries/OutcomeRefinery.ts
+++ b/.examples/tic-tac-toe/src/game-ship/refine/refineries/OutcomeRefinery.ts
@@ -15,7 +15,9 @@ const log = getTheseusLogger("OutcomeRefinery");
 /**
  * Refinery for checking the outcome of a game
  */
-export const OutcomeRefinery = Refinery.create("OutcomeRefinery", { noun: "gameState" })
+export const OutcomeRefinery = Refinery.create("OutcomeRefinery", {
+	noun: "gameState", 
+})
 	.toRefine<GameState>()
 	.withForges({
 		/**
@@ -67,11 +69,27 @@ export const OutcomeRefinery = Refinery.create("OutcomeRefinery", { noun: "gameS
 			const triples: Triple[] = [];
 			for (let i = 0; i < 3; i++) 
 			{
-				triples.push({ type: "row", from: [i, 0], to: [i, 2] });
-				triples.push({ type: "column", from: [0, i], to: [2, i] });
+				triples.push({
+					type: "row",
+					from: [i, 0],
+					to: [i, 2], 
+				});
+				triples.push({
+					type: "column",
+					from: [0, i],
+					to: [2, i], 
+				});
 			}
-			triples.push({ type: "diagonalLR", from: [0, 0], to: [2, 2] });
-			triples.push({ type: "diagonalRL", from: [0, 2], to: [2, 0] });
+			triples.push({
+				type: "diagonalLR",
+				from: [0, 0],
+				to: [2, 2], 
+			});
+			triples.push({
+				type: "diagonalRL",
+				from: [0, 2],
+				to: [2, 0], 
+			});
 			for (const triple of triples) 
 			{
 				const winner= OutcomeRefinery.refine(gameState).checkTriple(triple);

--- a/.examples/tic-tac-toe/src/game-ship/refine/refineries/RenderRefinery.ts
+++ b/.examples/tic-tac-toe/src/game-ship/refine/refineries/RenderRefinery.ts
@@ -2,7 +2,9 @@ import { Refinery } from "theseus-js";
 
 import type { Board, GameState } from "../../state/GameState";
 
-export const RenderRefinery = Refinery.create("RenderRefinery", { noun: "gameState" })
+export const RenderRefinery = Refinery.create("RenderRefinery", {
+	noun: "gameState", 
+})
 	.toRefine<GameState>()
 	.withForges({
 		renderToString: ({ gameState: { board } }) => 

--- a/.examples/tic-tac-toe/src/game-ship/refine/refineries/SquaresRefinery.ts
+++ b/.examples/tic-tac-toe/src/game-ship/refine/refineries/SquaresRefinery.ts
@@ -4,7 +4,9 @@ import type { CoordsArray, GameState } from "../../state/GameState";
 
 const log = getTheseusLogger("SquaresRefinery");
 
-export const SquaresRefinery = Refinery.create("SquaresRefinery", { noun: "gameState" })
+export const SquaresRefinery = Refinery.create("SquaresRefinery", {
+	noun: "gameState", 
+})
 	.toRefine<GameState>()
 	.withForges({
 		getSquare: ({ gameState }, coords: [number, number]) => 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,13 @@
 {
-	"arrowParens": "always",
-	"printWidth": 120,
-	"trailingComma": "all",
-	"tabWidth": 4,
-	"tabs": true,
-	"semi": true,
-	"singleQuote": false,
-	"bracketSpacing": true,
-	"bracketSameLine": false,
-	"proseWrap": "always",
-	"experimentalTernaries": true
+    "arrowParens": "always",
+    "printWidth": 120,
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "tabs": true,
+    "semi": true,
+    "singleQuote": false,
+    "bracketSpacing": true,
+    "bracketSameLine": false,
+    "proseWrap": "always",
+    "experimentalTernaries": false
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
             "request": "launch",
             "name": "Run Base Test (single)",
             "runtimeExecutable": "pnpm",
-            "runtimeArgs": ["test:base", "--timeout", "60000", "--", "--grep", "\"should return a new object copy that won't change after further evolutions\""],
+            "runtimeArgs": ["test:base", "--timeout", "60000", "--", "--grep", "\"should support evolvers with nested mutators\""],
             "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}",
             "outputCapture": "std"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "@semantic-release/github": "^10.0.5",
         "@semantic-release/npm": "^12.0.1",
         "@semantic-release/release-notes-generator": "^13.0.0",
+        "@stylistic/eslint-plugin": "^2.2.2",
         "@types/chai": "^4.3.12",
         "@types/chai-as-promised": "^7.1.8",
         "@types/deep-equal": "^1.0.4",

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -1,9 +1,8 @@
 import type {
 	RuleConfigCondition,
-	TargetCaseType } from "@commitlint/types";
-import {
-	RuleConfigSeverity,
+	TargetCaseType, 
 } from "@commitlint/types";
+import { RuleConfigSeverity } from "@commitlint/types";
 
 export default {
 	preset: "angular",
@@ -42,20 +41,53 @@ export default {
 	},
 	releaseRules: [
 		// major
-		{ breaking: true, release: "major" },
-		{ revert: true, release: "patch" },
+		{
+			breaking: true,
+			release: "major", 
+		},
+		{
+			revert: true,
+			release: "patch", 
+		},
 		// minor
-		{ type: "feat", release: "minor" },
-		{ type: "build", release: "minor" },
+		{
+			type: "feat",
+			release: "minor", 
+		},
+		{
+			type: "build",
+			release: "minor", 
+		},
 		// patch
-		{ type: "fix", release: "patch" },
-		{ type: "perf", release: "patch" },
-		{ type: "docs", release: "patch" },
-		{ type: "refactor", release: "patch" },
-		{ type: "style", release: "patch" },
+		{
+			type: "fix",
+			release: "patch", 
+		},
+		{
+			type: "perf",
+			release: "patch", 
+		},
+		{
+			type: "docs",
+			release: "patch", 
+		},
+		{
+			type: "refactor",
+			release: "patch", 
+		},
+		{
+			type: "style",
+			release: "patch", 
+		},
 		// none
-		{ type: "ci", release: false },
-		{ scope: "no-release", release: false },
+		{
+			type: "ci",
+			release: false, 
+		},
+		{
+			scope: "no-release",
+			release: false, 
+		},
 	],
 	prompt: {
 		questions: {

--- a/packages/eslint-plugin-theseus/lib/_test/break-on-chainable.test.js
+++ b/packages/eslint-plugin-theseus/lib/_test/break-on-chainable.test.js
@@ -5,7 +5,10 @@ const rule = require("../rules/break-on-chainable");
 
 // Use the appropriate parser if dealing with specific ECMAScript versions or TypeScript
 const ruleTester = new RuleTester({
-	parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+	parserOptions: {
+		ecmaVersion: 2020,
+		sourceType: "module", 
+	},
 });
 
 ruleTester.run("break-on-chainable", rule, {
@@ -32,32 +35,48 @@ ruleTester.run("break-on-chainable", rule, {
 		{
 			code: "obj.via.thing().and.anotherThing().lastly.thing();",
 			errors: [
-				{ message: "Expected line break before `.and`." },
-				{ message: "Expected line break before `.lastly`." },
+				{
+					message: "Expected line break before `.and`.", 
+				},
+				{
+					message: "Expected line break before `.lastly`.", 
+				},
 			],
 			output: "obj.via.thing()\n.and.anotherThing()\n.lastly.thing();",
 		},
 		{
 			code: "obj.via.thing().and.thing().end();",
 			errors: [
-				{ message: "Expected line break before `.and`." },
-				{ message: "Expected line break before `.end`." },
+				{
+					message: "Expected line break before `.and`.", 
+				},
+				{
+					message: "Expected line break before `.end`.", 
+				},
 			],
 			output: "obj.via.thing()\n.and.thing()\n.end();",
 		},
 		{
 			code: "obj.via.thing().and.thing().endAsync();",
 			errors: [
-				{ message: "Expected line break before `.and`." },
-				{ message: "Expected line break before `.endAsync`." },
+				{
+					message: "Expected line break before `.and`.", 
+				},
+				{
+					message: "Expected line break before `.endAsync`.", 
+				},
 			],
 			output: "obj.via.thing()\n.and.thing()\n.endAsync();",
 		},
 		{
 			code: "GameMeta.evolve.iterateTurnCount().and.updateLastPlayer(mark).and.updateLastPlayedCoords(coords);",
 			errors: [
-				{ message: "Expected line break before `.and`." },
-				{ message: "Expected line break before `.and`." },
+				{
+					message: "Expected line break before `.and`.", 
+				},
+				{
+					message: "Expected line break before `.and`.", 
+				},
 			],
 			output: "GameMeta.evolve.iterateTurnCount()\n.and.updateLastPlayer(mark)\n.and.updateLastPlayedCoords(coords);",
 		},

--- a/packages/eslint-plugin-theseus/lib/rules/break-on-chainable.js
+++ b/packages/eslint-plugin-theseus/lib/rules/break-on-chainable.js
@@ -29,20 +29,26 @@ module.exports = {
 
 		function isLikelyTheseus(node)
 		{
-			const tokens = sourceCode.getTokensBefore(node, { count: 20, filter: ({ type,value }) => 
-			{
-				return type === "Identifier" && targetedRoots.has(value);
-			} });
+			const tokens = sourceCode.getTokensBefore(node, {
+				count: 20,
+				filter: ({ type,value }) => 
+				{
+					return type === "Identifier" && targetedRoots.has(value);
+				}, 
+			});
 
 			return tokens.length > 0;
 		}
 
 		function isEndingMethodPrecededByChaining(node)
 		{
-			const tokens = sourceCode.getTokensBefore(node, { count: 20, filter: ({ type,value }) => 
-			{
-				return type === "Identifier" && chainingMethods.has(value);
-			} });
+			const tokens = sourceCode.getTokensBefore(node, {
+				count: 20,
+				filter: ({ type,value }) => 
+				{
+					return type === "Identifier" && chainingMethods.has(value);
+				}, 
+			});
 
 			return tokens.length > 0;
 		}
@@ -66,11 +72,15 @@ module.exports = {
 				if (matchingNodeName && isLikelyTheseus(node)) 
 				{
 					// Only consider the direct .property access case, ensuring it's part of a member expression chain
-					const tokenBeforeNode = sourceCode.getTokenBefore(node, { includeComments: false });
+					const tokenBeforeNode = sourceCode.getTokenBefore(node, {
+						includeComments: false, 
+					});
 					if (tokenBeforeNode && tokenBeforeNode.type === "Punctuator" && tokenBeforeNode.value === ".") 
 					{
 						const dotBeforeNode = tokenBeforeNode;
-						const tokenBeforeDot = sourceCode.getTokenBefore(dotBeforeNode, { includeComments: false });
+						const tokenBeforeDot = sourceCode.getTokenBefore(dotBeforeNode, {
+							includeComments: false, 
+						});
 
 						// Ensure `.via` is in the chain
 						if (tokenBeforeDot && tokenBeforeDot.loc.end.line === node.loc.start.line) 

--- a/packages/sandbox/lib/cement/_test/cement.test.ts
+++ b/packages/sandbox/lib/cement/_test/cement.test.ts
@@ -7,65 +7,117 @@ describe("cement", function()
 {
 	it("should modify the original object if it is a sandbox proxy in modify mode", function() 
 	{
-		const original = { key1: "value1", key2: "value2" };
-		const changes = { key2: "newValue2", key3: "value3" };
+		const original = {
+			key1: "value1",
+			key2: "value2", 
+		};
+		const changes = {
+			key2: "newValue2",
+			key3: "value3", 
+		};
 		const proxy = { 
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
-				params: { mode: "modify" }, 
+				params: {
+					mode: "modify", 
+				}, 
 			}, 
 		};
 
 		const result = cement(proxy);
 		expect(result).to.equal(original);  // Ensure that the result is the original object
-		expect(result).to.deep.equal({ key1: "value1", key2: "newValue2", key3: "value3" });
+		expect(result).to.deep.equal({
+			key1: "value1",
+			key2: "newValue2",
+			key3: "value3", 
+		});
 	});
 
 	it("should return a new object with changes applied if it is a sandbox proxy in copy mode", function() 
 	{
-		const original = { key1: "value1", key2: "value2" };
-		const changes = { key2: "newValue2", key3: "value3" };
+		const original = {
+			key1: "value1",
+			key2: "value2", 
+		};
+		const changes = {
+			key2: "newValue2",
+			key3: "value3", 
+		};
 		const proxy = { 
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
-				params: { mode: "copy" }, 
+				params: {
+					mode: "copy", 
+				}, 
 			}, 
 		};
 
 		// Mock the isSandboxProxy function to return true
 		
 		const result = cement(proxy);
-		expect(result).to.deep.equal({ key1: "value1", key2: "newValue2", key3: "value3" });
+		expect(result).to.deep.equal({
+			key1: "value1",
+			key2: "newValue2",
+			key3: "value3", 
+		});
 		expect(result).to.not.equal(original);  // Ensure that the result is a new object
 	});
 
 	it("should apply changes to a target object with nested objects which have changes", function()
 	{
-		const original = { key1: "value1", key2: { key3: "value3" } };
-		const changes = { key2: { key3: "newValue3", key4: "value" } };
+		const original = {
+			key1: "value1",
+			key2: {
+				key3: "value3", 
+			}, 
+		};
+		const changes = {
+			key2: {
+				key3: "newValue3",
+				key4: "value", 
+			}, 
+		};
 		const proxy = { 
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
-				params: { mode: "copy" }, 
+				params: {
+					mode: "copy", 
+				}, 
 			}, 
 		};
 
 		const result = cement(proxy) as any;
-		expect(result).to.deep.equal({ key1: "value1", key2: { key3: "newValue3", key4: "value" } });
+		expect(result).to.deep.equal({
+			key1: "value1",
+			key2: {
+				key3: "newValue3",
+				key4: "value", 
+			}, 
+		});
 		expect(result.key2).to.not.equal(original.key2);  // Ensure that the nested object is a new object
 		expect(result).to.not.equal(original);  // Ensure that the nested object is a new object
 	});
 
 	it("should find no remaining sandboxes in nested functions", function()
 	{
-		const original = { key1: "value1", key2: { key3: "value3" } };
+		const original = {
+			key1: "value1",
+			key2: {
+				key3: "value3", 
+			}, 
+		};
 		const sb = sandbox(original);
 		sb.key2.key3 = "replacement";
 		const result = cement(sb);
-		expect(result).to.deep.equal({ key1: "value1", key2: { key3: "replacement" } });
+		expect(result).to.deep.equal({
+			key1: "value1",
+			key2: {
+				key3: "replacement", 
+			}, 
+		});
 
 		const checkForSandbox = (obj: any) =>
 		{

--- a/packages/sandbox/lib/cement/cement.ts
+++ b/packages/sandbox/lib/cement/cement.ts
@@ -21,9 +21,7 @@ export function cement<T extends object>(obj: T): T
 		const {
 			original,
 			changes,
-			params: {
-				mode,
-			},
+			params: { mode },
 		} = obj[CONSTANTS.SANDBOX_SYMBOL];
 
 		const toModify = getModifiableObject(original, mode);
@@ -64,7 +62,9 @@ function getModifiableObject<T extends object>(obj: T, mode: SandboxMode): T
 		// if the object is a frost proxy, clone it and frost it, otherwise structured clone it
 		result = isFrostProxy(obj) 
 			? frostClone(obj) 
-			: structuredClone(obj, { lossy: false });
+			: structuredClone(obj, {
+				lossy: false, 
+			});
 	}
 
 	return result;

--- a/packages/sandbox/lib/frost/_test/index.test.ts
+++ b/packages/sandbox/lib/frost/_test/index.test.ts
@@ -10,7 +10,10 @@ describe("frost", function()
 
 	beforeEach(function() 
 	{
-		originalObject = { a: 1, b: 2 };
+		originalObject = {
+			a: 1,
+			b: 2, 
+		};
 		frostedProxy = frost(originalObject);
 	});
 
@@ -38,7 +41,9 @@ describe("frost", function()
 
 	it("should allow modification of a property via sandbox", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "modify" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "modify", 
+		});
 		expect(() => 
 		{
 			sandboxFrostedProxy.a = 3;
@@ -47,7 +52,9 @@ describe("frost", function()
 
 	it("should allow deletion of a property via sandbox", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "modify" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "modify", 
+		});
 		expect(() => 
 		{
 			delete sandboxFrostedProxy.a;
@@ -56,7 +63,9 @@ describe("frost", function()
 
 	it("should allow cementing of a frosted sandbox with deletion", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "modify" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "modify", 
+		});
 		delete sandboxFrostedProxy.a;
 		cement(sandboxFrostedProxy);
 	});
@@ -64,7 +73,9 @@ describe("frost", function()
 
 	it("should allow cementing of a frosted sandbox with change", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "modify" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "modify", 
+		});
 		sandboxFrostedProxy.a = 5;
 		const result = cement(sandboxFrostedProxy);
 		expect(result.a).to.equal(5);
@@ -74,7 +85,9 @@ describe("frost", function()
 
 	it("should get same stringified value for frosted proxy and original object", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "modify" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "modify", 
+		});
 		sandboxFrostedProxy.a = 5;
 		const result = cement(sandboxFrostedProxy);
 
@@ -86,7 +99,9 @@ describe("frost", function()
 
 	it("should not get same stringified value for frosted proxy and original object", function()
 	{
-		const sandboxFrostedProxy = sandbox(frostedProxy, { mode: "copy" });
+		const sandboxFrostedProxy = sandbox(frostedProxy, {
+			mode: "copy", 
+		});
 		sandboxFrostedProxy.a = 5;
 		const result = cement(sandboxFrostedProxy);
 

--- a/packages/sandbox/lib/frost/_test/properties.test.ts
+++ b/packages/sandbox/lib/frost/_test/properties.test.ts
@@ -42,7 +42,10 @@ describe("propertyStartsWith", function()
 	{
 		const input = "__verify_123__propName";
 		const result = extractVerificationPropValues(input);
-		expect(result).to.deep.equal({ verificationValue: "123", propertyName: "propName" });
+		expect(result).to.deep.equal({
+			verificationValue: "123",
+			propertyName: "propName", 
+		});
 	});
 
 	it("should return undefined if the input string does not match the pattern", function() 

--- a/packages/sandbox/lib/frost/frost.ts
+++ b/packages/sandbox/lib/frost/frost.ts
@@ -1,6 +1,8 @@
 import { v4 as uuidv4 } from "uuid";
 import { CONSTANTS } from "../constants";
-import { proxyDelete, proxyGet, proxySet } from "./proxy-traps";
+import {
+	proxyDelete, proxyGet, proxySet, 
+} from "./proxy-traps";
 import type { FrostProxy } from "./types";
 import type { SandboxProxy } from "../sandbox";
 import structuredClone from "@ungap/structured-clone";
@@ -51,7 +53,9 @@ export function frost<T extends object>(originalObject: T): Readonly<T>
 
 export function frostClone<T extends object>(originalObject: T): Readonly<T> 
 {
-	const clone = structuredClone(originalObject, { lossy: false });
+	const clone = structuredClone(originalObject, {
+		lossy: false, 
+	});
 	delete (clone as any)[CONSTANTS.FROST.BASIS_SYMBOL];
 
 	return frost(clone);

--- a/packages/sandbox/lib/frost/properties.ts
+++ b/packages/sandbox/lib/frost/properties.ts
@@ -19,7 +19,10 @@ export function extractVerificationPropValues(input: string)
 	if (match) 
 	{
 		const [_, verificationValue, propertyName] = match;
-		return { verificationValue, propertyName };
+		return {
+			verificationValue,
+			propertyName, 
+		};
 	}
 }
 

--- a/packages/sandbox/lib/frost/proxy-traps/_test/proxy-delete.test.ts
+++ b/packages/sandbox/lib/frost/proxy-traps/_test/proxy-delete.test.ts
@@ -4,25 +4,37 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { CONSTANTS } from "../../../constants";
 import { proxyDelete } from "../proxy-delete";
-import { extractVerificationPropValues, generateVerificationProperty, propertyStartsWith } from "../../properties";
+import {
+	extractVerificationPropValues, generateVerificationProperty, propertyStartsWith, 
+} from "../../properties";
 import { assertValidVerificationProperty } from "../../assertions";
 
 describe("proxyDelete", function() 
 {
 	it("should delete the verification property", function() 
 	{
-		const target = { [CONSTANTS.FROST.BASIS_SYMBOL]: "123" };
+		const target = {
+			[CONSTANTS.FROST.BASIS_SYMBOL]: "123", 
+		};
 
-		proxyDelete(target, CONSTANTS.FROST.BASIS_SYMBOL, { proxy: target });
+		proxyDelete(target, CONSTANTS.FROST.BASIS_SYMBOL, {
+			proxy: target, 
+		});
 		expect(target[CONSTANTS.FROST.BASIS_SYMBOL]).to.be.undefined;
 	});
 
 	it("should delete the sandbox property with valid verification", function() 
 	{
-		const target = { key: "value", [CONSTANTS.FROST.BASIS_SYMBOL]: "123" };
+		const target = {
+			key: "value",
+			[CONSTANTS.FROST.BASIS_SYMBOL]: "123", 
+		};
 		const ostensibleProp = generateVerificationProperty(target, "key");
 
-		const propValues = { verificationValue: "123", propertyName: "key" };
+		const propValues = {
+			verificationValue: "123",
+			propertyName: "key", 
+		};
 
 		// Directly stub the functions without using withArgs
 		const propertyStub = sinon.stub().returns(true);
@@ -37,7 +49,9 @@ describe("proxyDelete", function()
 		(global as any).extractVerificationPropValues = extractStub;
 		(global as any).assertValidVerificationProperty = assertStub;
 	
-		expect(() => proxyDelete(target, ostensibleProp, { proxy: target })).not.to.throw();
+		expect(() => proxyDelete(target, ostensibleProp, {
+			proxy: target, 
+		})).not.to.throw();
 		expect(target.key).to.be.undefined;
 	
 		// Restore the original functions
@@ -48,9 +62,13 @@ describe("proxyDelete", function()
 
 	it("should throw an error for other properties", function() 
 	{
-		const target = { key: "value" };
+		const target = {
+			key: "value", 
+		};
 		const ostensibleProp = "key";
 
-		expect(() => proxyDelete(target, ostensibleProp, { proxy: target })).to.throw("Cannot modify property \"key\" of the original object.");
+		expect(() => proxyDelete(target, ostensibleProp, {
+			proxy: target, 
+		})).to.throw("Cannot modify property \"key\" of the original object.");
 	});
 });

--- a/packages/sandbox/lib/frost/proxy-traps/_test/proxy-get.test.ts
+++ b/packages/sandbox/lib/frost/proxy-traps/_test/proxy-get.test.ts
@@ -18,7 +18,10 @@ describe("proxyGet", function()
 		};
 
 		// Create stubs for the external functions
-		const extractStub = sinon.stub().returns({ verificationValue, propertyName: "propName" });
+		const extractStub = sinon.stub().returns({
+			verificationValue,
+			propertyName: "propName", 
+		});
 		const assertStub = sinon.stub().returns(true);
 
 		// Replace the actual functions with the stubs
@@ -51,7 +54,9 @@ describe("proxyGet", function()
 
 	it("should return the target property for other properties", function() 
 	{
-		const target = { key: "value" };
+		const target = {
+			key: "value", 
+		};
 		const prop = "key";
 		const result = proxyGet(target, prop, {
 			guid: "123",

--- a/packages/sandbox/lib/frost/proxy-traps/_test/proxy-set.test.ts
+++ b/packages/sandbox/lib/frost/proxy-traps/_test/proxy-set.test.ts
@@ -18,7 +18,9 @@ describe("proxySet", function()
 			[SANDBOX_VERIFIABLE_PROP_SYMBOL]: "123",
 		};
 
-		const result = proxySet(target, CONSTANTS.FROST.SETTER_SYMBOL, value, { proxy: target });
+		const result = proxySet(target, CONSTANTS.FROST.SETTER_SYMBOL, value, {
+			proxy: target, 
+		});
 		expect(result).to.be.true;
 		expect(target["key"]).to.equal("newValue");
 	});
@@ -29,6 +31,8 @@ describe("proxySet", function()
 		const ostensibleProp = "key";
 		const ostensibleValue = "value";
 
-		expect(() => proxySet(target, ostensibleProp, ostensibleValue, { proxy: target })).to.throw("Cannot modify property \"key\" of the original object.");
+		expect(() => proxySet(target, ostensibleProp, ostensibleValue, {
+			proxy: target, 
+		})).to.throw("Cannot modify property \"key\" of the original object.");
 	});
 });

--- a/packages/sandbox/lib/reject/_test/reject.test.ts
+++ b/packages/sandbox/lib/reject/_test/reject.test.ts
@@ -7,8 +7,14 @@ describe("reject", function()
 {
 	it("should return the original object if it is a sandbox proxy", function() 
 	{
-		const original = { key: "value" };
-		const proxy = { [CONSTANTS.SANDBOX_SYMBOL]: { original } };
+		const original = {
+			key: "value", 
+		};
+		const proxy = {
+			[CONSTANTS.SANDBOX_SYMBOL]: {
+				original, 
+			}, 
+		};
     
 		// Mock the isSandboxProxy function to return true
 		isSandboxProxy(proxy);
@@ -17,7 +23,9 @@ describe("reject", function()
 
 	it("should return the object itself if it is not a sandbox proxy", function() 
 	{
-		const obj = { key: "value" };
+		const obj = {
+			key: "value", 
+		};
 		// Mock the isSandboxProxy function to return false
 		isSandboxProxy(obj);
 		expect(reject(obj)).to.equal(obj);

--- a/packages/sandbox/lib/sandbox/_test/get-sandbox-changes.test.ts
+++ b/packages/sandbox/lib/sandbox/_test/get-sandbox-changes.test.ts
@@ -6,7 +6,9 @@ describe("getSandboxChanges", function()
 {
 	it("should return changes when input is a sandbox proxy", function() 
 	{
-		const changes = { some: "changes" };
+		const changes = {
+			some: "changes", 
+		};
 		const sandboxProxy = {
 			[CONSTANTS.SANDBOX_SYMBOL]: {
 				changes,

--- a/packages/sandbox/lib/sandbox/_test/is-sandbox-proxy.test.ts
+++ b/packages/sandbox/lib/sandbox/_test/is-sandbox-proxy.test.ts
@@ -7,14 +7,20 @@ describe("is-sandbox-proxy", function()
 {
 	it("should correctly identify a sandbox proxy object", function() 
 	{
-		const original = { a: 1, b: 2 };
+		const original = {
+			a: 1,
+			b: 2, 
+		};
 		const proxy = sandbox(original);
 		expect(isSandboxProxy(proxy)).to.equal(true);
 	});
 
 	it("should correctly identify a non-sandbox proxy object", function() 
 	{
-		const original = { a: 1, b: 2 };
+		const original = {
+			a: 1,
+			b: 2, 
+		};
 		expect(isSandboxProxy(original)).to.equal(false);
 	});
 });

--- a/packages/sandbox/lib/sandbox/_test/sandbox.test.ts
+++ b/packages/sandbox/lib/sandbox/_test/sandbox.test.ts
@@ -8,7 +8,10 @@ describe("sandbox", function()
 {
 	it("should create a sandbox proxy for the given object", function() 
 	{
-		const original = { a: 1, b: 2 };
+		const original = {
+			a: 1,
+			b: 2, 
+		};
 		const proxy = sandbox(original);
 		expect(proxy).not.to.equal(original);
 		expect(proxy.a).to.equal(1);
@@ -17,8 +20,13 @@ describe("sandbox", function()
 
 	it('should allow modifications if the mode is "modify"', function() 
 	{
-		const original = { a: 1, b: 2 };
-		const proxy = sandbox(original, { mode: "modify" });
+		const original = {
+			a: 1,
+			b: 2, 
+		};
+		const proxy = sandbox(original, {
+			mode: "modify", 
+		});
 		proxy.a = 3;
 		expect(proxy.a).to.equal(3);
 		expect(original.a).to.equal(1);  // original should not be modified
@@ -26,8 +34,13 @@ describe("sandbox", function()
 
 	it('should allow modifications if the mode is "copy"', function() 
 	{
-		const original = { a: 1, b: 2 };
-		const proxy = sandbox(original, { mode: "copy" });
+		const original = {
+			a: 1,
+			b: 2, 
+		};
+		const proxy = sandbox(original, {
+			mode: "copy", 
+		});
 		expect(() => 
 		{
 			proxy.a = 3;
@@ -36,7 +49,10 @@ describe("sandbox", function()
 
 	it("should track changes made to the proxy object", function() 
 	{
-		const original = { a: 1, b: 2 };
+		const original = {
+			a: 1,
+			b: 2, 
+		};
 		const proxy = sandbox(original);
 		proxy.a = 3;
 		expect((proxy as any)[CONSTANTS.SANDBOX_SYMBOL].changes.a).to.equal(3);
@@ -44,7 +60,12 @@ describe("sandbox", function()
 
 	it("should create a proxy of nested objects as well", function()
 	{
-		const original = { a: { b: 1, c: 2 } };
+		const original = {
+			a: {
+				b: 1,
+				c: 2, 
+			}, 
+		};
 		const proxy = sandbox(original);
 
 		const recursiveCheckIfProxy = (obj: any) => 
@@ -62,30 +83,49 @@ describe("sandbox", function()
 
 	it("should not proxy the sandbox symbol", function()
 	{
-		const original = { a: 1, b: 2 };
+		const original = {
+			a: 1,
+			b: 2, 
+		};
 		const proxy = sandbox(original) as any;
 		expect(proxy[CONSTANTS.SANDBOX_SYMBOL][CONSTANTS.SANDBOX_SYMBOL]).to.be.undefined;
 	});
 
 	it("should sandbox changes that replace nested objects", function() 
 	{
-		const original: any = { a: { b: 1, c: 2 } };
+		const original: any = {
+			a: {
+				b: 1,
+				c: 2, 
+			}, 
+		};
 		const proxy = sandbox(original);
-		proxy.a = { d: 3, e: 4 };
+		proxy.a = {
+			d: 3,
+			e: 4, 
+		};
 		expect(isSandboxProxy(proxy.a)).to.be.true;
 
 	});
 
 	it("should sandbox arrays nested in objects", function()
 	{
-		const original: any = { a: [1, 2, 3] };
+		const original: any = {
+			a: [1, 2, 3], 
+		};
 		const proxy = sandbox(original);
 		expect(isSandboxProxy(proxy.a)).to.be.true;
 	});
 
 	it("should sandbox objects nested in arrays nested in objects", function() 
 	{
-		const original: any = { a: [{ b: 1 }, { c: 2 }] };
+		const original: any = {
+			a: [{
+				b: 1, 
+			}, {
+				c: 2, 
+			}], 
+		};
 		const proxy = sandbox(original);
 		expect(isSandboxProxy(proxy.a[0])).to.be.true;
 		expect(isSandboxProxy(proxy.a[1])).to.be.true;
@@ -93,7 +133,13 @@ describe("sandbox", function()
 
 	it("should correctly process changes to objects nested in arrays nested in objects", function() 
 	{
-		const original: any = { a: [{ b: 1 }, { c: 2 }] };
+		const original: any = {
+			a: [{
+				b: 1, 
+			}, {
+				c: 2, 
+			}], 
+		};
 		const proxy = sandbox(original);
 		proxy.a[0].b = 3;
 		expect(proxy.a[0].b).to.equal(3);
@@ -108,8 +154,16 @@ describe("sandbox", function()
 
 	it("should correctly process changes to objects nested in arrays nested in objects, and keep the original intact in copy mode", function() 
 	{
-		const original: any = { a: [{ b: 1 }, { c: 2 }] };
-		const proxy = sandbox(original, { mode: "copy" });
+		const original: any = {
+			a: [{
+				b: 1, 
+			}, {
+				c: 2, 
+			}], 
+		};
+		const proxy = sandbox(original, {
+			mode: "copy", 
+		});
 		proxy.a[0].b = 3;
 		expect(proxy.a[0].b).to.equal(3);
 		expect(original.a[0].b).to.equal(1);
@@ -122,7 +176,9 @@ describe("sandbox", function()
 
 	it("should not sandbox nullish values", function()
 	{
-		const original: any = { a: null };
+		const original: any = {
+			a: null, 
+		};
 		let proxy: any;
 		expect(() => {proxy = sandbox(original);}).not.to.throw();
 		expect(isSandboxProxy(proxy.a)).to.be.false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@semantic-release/release-notes-generator':
         specifier: ^13.0.0
         version: 13.0.0(semantic-release@23.1.1(typescript@5.4.5))
+      '@stylistic/eslint-plugin':
+        specifier: ^2.2.2
+        version: 2.2.2(eslint@8.57.0)(typescript@5.4.5)
       '@types/chai':
         specifier: ^4.3.12
         version: 4.3.16
@@ -935,6 +938,35 @@ packages:
   '@sinonjs/text-encoding@0.7.2':
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
 
+  '@stylistic/eslint-plugin-js@2.2.2':
+    resolution: {integrity: sha512-Vj2Q1YHVvJw+ThtOvmk5Yx7wZanVrIBRUTT89horLDb4xdP9GA1um9XOYQC6j67VeUC2gjZQnz5/RVJMzaOhtw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  '@stylistic/eslint-plugin-jsx@2.2.2':
+    resolution: {integrity: sha512-xfIMdLivoMV1wV+5Tl0PtkLN/oUwjIt7LuIu48vhrZfJ2jCXwjlTGPGSoM7dnLZYD65XjtrHHIFAvPuvvvjlaw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  '@stylistic/eslint-plugin-plus@2.2.2':
+    resolution: {integrity: sha512-oeqPs01yAH4ad4bSchGtx8Jf5XTbxRx++A0joNYiOoq3EBTAUHE/ZB7dVv3BhNuCKiwojOQduLkUCXI5UMHoSw==}
+    peerDependencies:
+      eslint: '*'
+
+  '@stylistic/eslint-plugin-ts@2.2.2':
+    resolution: {integrity: sha512-n6cYMSWTDDcrQLLxEKIrL/ihQ1lyyq6+gGp0g5VdstBElmImSRsQkCq+g3jRoDJIUo7tGO9lwQtGnuJ7oGB4kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  '@stylistic/eslint-plugin@2.2.2':
+    resolution: {integrity: sha512-GNRtyhhPsc9I9FNTaU2L0V/4LdSPAciQNEdYo6NBRdAz7sdiaxgEJKLNSXeXSQAuO9JBWWjZBs/57+WvrU0Iug==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
   '@types/chai-as-promised@7.1.8':
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
 
@@ -952,6 +984,9 @@ packages:
 
   '@types/deep-freeze-strict@1.1.2':
     resolution: {integrity: sha512-VvMETBojHvhX4f+ocYTySQlXMZfxKV3Jyb7iCWlWaC+exbedkv6Iv2bZZqI736qXjVguH6IH7bzwMBMfTT+zuQ==}
+
+  '@types/eslint@8.56.10':
+    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -1017,6 +1052,10 @@ packages:
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/scope-manager@7.14.0':
+    resolution: {integrity: sha512-Plcp2+3jkQz/WD7YKJxqtQ/1uqVkyFTv2TgG3K4e4cVt5fNbVNaojX89PpCAZ9eKbSs596s1n9eiZQkQPorsJg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
   '@typescript-eslint/type-utils@6.21.0':
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1031,9 +1070,22 @@ packages:
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/types@7.14.0':
+    resolution: {integrity: sha512-m5s+5+QQ/2cFLMmsPq2SlgNnK6V3UhcedMve20k6ctRPZnarIR4MV2nBw4dFEDxSRre7SQnUX6mXOpxVhJbUFg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
   '@typescript-eslint/typescript-estree@6.21.0':
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@7.14.0':
+    resolution: {integrity: sha512-M6K5sw1anuswkxgUvjPgSVKbiw/2qeOrq+81ts0U48PS+ocA/YT1F+MAJ2JQkB7CGJXL8ENvo61KBLW5DmMSmA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1046,9 +1098,19 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
 
+  '@typescript-eslint/utils@7.14.0':
+    resolution: {integrity: sha512-q817i3Pqz3W9hNFJxVUn+Dg05jy9VyKFet1kw3TuSby7Pubyo3ZBSadRd0RBacaSs9A5BmtNaI6lnw7MVpBXpQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@7.14.0':
+    resolution: {integrity: sha512-OjXoB9vX6YnLI2qHPGO6EFZjzYZ92eWeev6aJITlhjpebc00zw70hZ0vONC+IhTkEvdedh3XhglNIZA8DtN7zw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -1087,6 +1149,11 @@ packages:
 
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.12.0:
+    resolution: {integrity: sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1740,10 +1807,18 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.0.0:
+    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
+
+  espree@10.1.0:
+    resolution: {integrity: sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -3008,6 +3083,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -4494,6 +4573,53 @@ snapshots:
 
   '@sinonjs/text-encoding@0.7.2': {}
 
+  '@stylistic/eslint-plugin-js@2.2.2(eslint@8.57.0)':
+    dependencies:
+      '@types/eslint': 8.56.10
+      acorn: 8.11.3
+      eslint: 8.57.0
+      eslint-visitor-keys: 4.0.0
+      espree: 10.1.0
+
+  '@stylistic/eslint-plugin-jsx@2.2.2(eslint@8.57.0)':
+    dependencies:
+      '@stylistic/eslint-plugin-js': 2.2.2(eslint@8.57.0)
+      '@types/eslint': 8.56.10
+      eslint: 8.57.0
+      estraverse: 5.3.0
+      picomatch: 4.0.2
+
+  '@stylistic/eslint-plugin-plus@2.2.2(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@types/eslint': 8.56.10
+      '@typescript-eslint/utils': 7.14.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@stylistic/eslint-plugin-ts@2.2.2(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@stylistic/eslint-plugin-js': 2.2.2(eslint@8.57.0)
+      '@types/eslint': 8.56.10
+      '@typescript-eslint/utils': 7.14.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@stylistic/eslint-plugin@2.2.2(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@stylistic/eslint-plugin-js': 2.2.2(eslint@8.57.0)
+      '@stylistic/eslint-plugin-jsx': 2.2.2(eslint@8.57.0)
+      '@stylistic/eslint-plugin-plus': 2.2.2(eslint@8.57.0)(typescript@5.4.5)
+      '@stylistic/eslint-plugin-ts': 2.2.2(eslint@8.57.0)(typescript@5.4.5)
+      '@types/eslint': 8.56.10
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@types/chai-as-promised@7.1.8':
     dependencies:
       '@types/chai': 4.3.16
@@ -4509,6 +4635,11 @@ snapshots:
   '@types/deep-extend@0.6.2': {}
 
   '@types/deep-freeze-strict@1.1.2': {}
+
+  '@types/eslint@8.56.10':
+    dependencies:
+      '@types/estree': 1.0.5
+      '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.5': {}
 
@@ -4581,6 +4712,11 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
+  '@typescript-eslint/scope-manager@7.14.0':
+    dependencies:
+      '@typescript-eslint/types': 7.14.0
+      '@typescript-eslint/visitor-keys': 7.14.0
+
   '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
@@ -4595,6 +4731,8 @@ snapshots:
 
   '@typescript-eslint/types@6.21.0': {}
 
+  '@typescript-eslint/types@7.14.0': {}
+
   '@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
@@ -4603,6 +4741,21 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.14.0(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/types': 7.14.0
+      '@typescript-eslint/visitor-keys': 7.14.0
+      debug: 4.3.5
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
       semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
@@ -4624,9 +4777,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.14.0(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 7.14.0
+      '@typescript-eslint/types': 7.14.0
+      '@typescript-eslint/typescript-estree': 7.14.0(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@6.21.0':
     dependencies:
       '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@7.14.0':
+    dependencies:
+      '@typescript-eslint/types': 7.14.0
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -4663,7 +4832,13 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-jsx@5.3.2(acorn@8.12.0):
+    dependencies:
+      acorn: 8.12.0
+
   acorn@8.11.3: {}
+
+  acorn@8.12.0: {}
 
   agent-base@7.1.1:
     dependencies:
@@ -5428,6 +5603,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.0.0: {}
+
   eslint@8.57.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -5470,6 +5647,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.1.0:
+    dependencies:
+      acorn: 8.12.0
+      acorn-jsx: 5.3.2(acorn@8.12.0)
+      eslint-visitor-keys: 4.0.0
 
   espree@9.6.1:
     dependencies:
@@ -6668,6 +6851,8 @@ snapshots:
   picocolors@1.0.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pidtree@0.6.0: {}
 

--- a/src/Theseus.ts
+++ b/src/Theseus.ts
@@ -9,7 +9,9 @@ import TheseusBuilder from "./TheseusBuilder";
 import type { BroadcasterObserver } from "@Broadcast/BroadcasterObserver";
 import type { DestroyCallback } from "./lib/Broadcast/Broadcaster";
 import type { BaseParams, ITheseus } from "@Types/Theseus";
-import { cement, frost, sandbox } from "theseus-sandbox";
+import {
+	cement, frost, sandbox, 
+} from "theseus-sandbox";
 
 const log = getTheseusLogger("Observation");
 
@@ -61,7 +63,9 @@ export class Theseus<
 
 	private setData = (data: TData) => 
 	{
-		this.internalState = sandbox(frost(data), { mode: "copy" });
+		this.internalState = sandbox(frost(data), {
+			mode: "copy", 
+		});
 	};
 
 	/**

--- a/src/TheseusBuilder.ts
+++ b/src/TheseusBuilder.ts
@@ -66,7 +66,9 @@ export default <TData extends object>(data: TData) => ({
 		params: TheseusParams<TData, TParamNoun, TMutators, TEvolvers, TForges, TRefineries, TObserverType>,
 	) => 
 	{
-		const { evolvers, refineries, ...rest } = params;
+		const {
+			evolvers, refineries, ...rest 
+		} = params;
 		const theseusInstance = Theseus.__private_create<TData, TObserverType>(data, rest);
 
         type ParamsAbbrev = TheseusParams<
@@ -130,7 +132,10 @@ export default <TData extends object>(data: TData) => ({
                     	:   RefineryComplex.create<TData>().withRefineries(...refineries);
 
         		extension = Object.defineProperties<BaseExtension>(
-                    { ...extension, refine: undefined } as any,
+                    {
+                    	...extension,
+                    	refine: undefined, 
+                    } as any,
                     {
                     	refine: {
                     		get: () => 

--- a/src/_test/Theseus.test.ts
+++ b/src/_test/Theseus.test.ts
@@ -1,6 +1,8 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { beforeEach, describe, it } from "mocha";
+import {
+	beforeEach, describe, it, 
+} from "mocha";
 import sinon, { type SinonSpy } from "sinon";
 
 import { Theseus } from "@/Theseus";
@@ -14,13 +16,17 @@ describe("Observation", () =>
 
 	beforeEach(() => 
 	{
-		observation = Theseus.__private_create<{ test: string }>({ test: "initial" });
+		observation = Theseus.__private_create<{ test: string }>({
+			test: "initial", 
+		});
 	});
 
 	it("should initialize with provided initial data", () => 
 	{
 		// JSON.stringify ignores symbols, which helpfully avoids sandbox symbols
-		expect(JSON.stringify(observation.state)).to.equal(JSON.stringify({ test: "initial" }));
+		expect(JSON.stringify(observation.state)).to.equal(JSON.stringify({
+			test: "initial", 
+		}));
 	});
 
 	it("should allow observers to subscribe and receive updates", async () => 
@@ -28,8 +34,12 @@ describe("Observation", () =>
 		const callback = sinon.fake();
 		observation.observe(callback);
 
-		await observation["update"]({ test: "updated" });
-		expect(callback.calledWith({ test: "updated" })).to.be.true;
+		await observation["update"]({
+			test: "updated", 
+		});
+		expect(callback.calledWith({
+			test: "updated", 
+		})).to.be.true;
 
 		return;
 	});
@@ -42,7 +52,9 @@ describe("Observation", () =>
 		await new Promise((resolve) => setTimeout(resolve, 100));
 
 		expect(callback.calledOnce).to.be.true;
-		expect(callback.calledWith({ test: "initial" })).to.be.true;
+		expect(callback.calledWith({
+			test: "initial", 
+		})).to.be.true;
 
 		return;
 	});
@@ -60,9 +72,15 @@ describe("Observation", () =>
 		const callback = sinon.fake();
 		observation.observe(callback);
 
-		await observation["update"]({ test: "new value" });
-		expect(JSON.stringify(observation.state)).to.deep.equal(JSON.stringify({ test: "new value" }));
-		expect(callback.calledWith({ test: "new value" })).to.be.true;
+		await observation["update"]({
+			test: "new value", 
+		});
+		expect(JSON.stringify(observation.state)).to.deep.equal(JSON.stringify({
+			test: "new value", 
+		}));
+		expect(callback.calledWith({
+			test: "new value", 
+		})).to.be.true;
 
 		return;
 	});
@@ -73,21 +91,29 @@ describe("Observation", () =>
 		const callback = sinon.fake();
 		observation.observe(callback);
 
-		await Theseus.updateInstance(id, { test: "static update" });
+		await Theseus.updateInstance(id, {
+			test: "static update", 
+		});
 
 		// Since updateInstance is async, we may need to wait or use fake timers
 		// This example assumes immediate update for simplicity
-		expect(callback.calledWith({ test: "static update" })).to.be.true;
+		expect(callback.calledWith({
+			test: "static update", 
+		})).to.be.true;
 
 		return;
 	});
 
 	it("should correctly return changes made to the state when requested", async () => 
 	{
-		const data = { myString: "happy" };
+		const data = {
+			myString: "happy", 
+		};
 		const instance = theseus(data).maintainWith({
 			evolvers: [
-				Evolver.create("TestEvolver", { noun: "data" }).toEvolve<{ myString: string }>().withMutators({
+				Evolver.create("TestEvolver", {
+					noun: "data", 
+				}).toEvolve<{ myString: string }>().withMutators({
 					reverse: ({ data }) => 
 					{
 						data.myString = data.myString.split("").reverse().join("");
@@ -99,17 +125,23 @@ describe("Observation", () =>
 		instance.evolve.Test.reverse();
 
 		const changes = instance.evolve.Test.getChanges();
-		expect(changes).to.deep.equal({ myString: "yppah" });
+		expect(changes).to.deep.equal({
+			myString: "yppah", 
+		});
 
 		return;
 	});
 
 	it("should not broadcast changes when evolver is called from within an evolver", async function() 
 	{
-		const data = { myString: "happy" };
+		const data = {
+			myString: "happy", 
+		};
 		const instance = theseus(data).maintainWith({
 			evolvers: [
-				Evolver.create("TestEvolver", { noun: "data" }).toEvolve<{ myString: string }>().withMutators({
+				Evolver.create("TestEvolver", {
+					noun: "data", 
+				}).toEvolve<{ myString: string }>().withMutators({
 					reverse: ({ data }) => 
 					{
 						data.myString = data.myString.split("").reverse().join("");

--- a/src/_test/TheseusBuilder.test.ts
+++ b/src/_test/TheseusBuilder.test.ts
@@ -5,7 +5,9 @@ import { getTheseusLogger } from "@Shared/index";
 
 // Mock external dependencies and types
 // Assuming these mock functions and classes are implemented elsewhere in the test suite
-import { mockEvolverComplex, mockRefineryComplex, type MockData } from "./mocks";
+import {
+	mockEvolverComplex, mockRefineryComplex, type MockData, 
+} from "./mocks";
 
 describe("TheseusBuilder", function () 
 {
@@ -24,7 +26,9 @@ describe("TheseusBuilder", function ()
 
 	it("extends a Theseus instance with evolvers correctly", function () 
 	{
-		const theseusInstance = TheseusBuilder<MockData>({ touched: false }).maintainWith({
+		const theseusInstance = TheseusBuilder<MockData>({
+			touched: false, 
+		}).maintainWith({
 			evolvers: mockEvolverComplex,
 		});
 
@@ -49,7 +53,9 @@ describe("TheseusBuilder", function ()
 
 	it("extends a Theseus instance with evolvers and refineries correctly", function () 
 	{
-		const theseusInstance = TheseusBuilder<MockData>({ touched: false }).maintainWith({
+		const theseusInstance = TheseusBuilder<MockData>({
+			touched: false, 
+		}).maintainWith({
 			evolvers: mockEvolverComplex,
 			refineries: mockRefineryComplex,
 		});

--- a/src/_test/mocks.ts
+++ b/src/_test/mocks.ts
@@ -1,11 +1,15 @@
-import { Evolver, EvolverComplex, Refinery, RefineryComplex } from "../lib";
+import {
+	Evolver, EvolverComplex, Refinery, RefineryComplex, 
+} from "../lib";
 
 export interface MockData {
     touched: boolean;
 }
 
 export const mockRefineryComplex = RefineryComplex.create().withRefineries(
-	Refinery.create("mockRefinery", { noun: "mockData" })
+	Refinery.create("mockRefinery", {
+		noun: "mockData", 
+	})
 		.toRefine<MockData>()
 		.withForges({
 			getOppositeOfTouched: ({ mockData }) => 
@@ -15,7 +19,9 @@ export const mockRefineryComplex = RefineryComplex.create().withRefineries(
 		}),
 );
 
-const mockEvolver = Evolver.create("mock", { noun: "mockData" }).toEvolve<MockData>().withMutators({
+const mockEvolver = Evolver.create("mock", {
+	noun: "mockData", 
+}).toEvolve<MockData>().withMutators({
 	toggleTouch: ({ mockData }) => 
 	{
 		mockData.touched = !mockData.touched;

--- a/src/lib/Broadcast/Broadcaster.ts
+++ b/src/lib/Broadcast/Broadcaster.ts
@@ -44,7 +44,9 @@ export class Broadcaster<
 	{
 		const broadcastTo = this.getObserversToUpdate(data);
 
-		log.verbose("Broadcasting data to observers", { count: broadcastTo.length });
+		log.verbose("Broadcasting data to observers", {
+			count: broadcastTo.length, 
+		});
 
 		// Assign a guid to this broadcast
 		const updateGuid = uuidv4();
@@ -64,7 +66,9 @@ export class Broadcaster<
 		)
 			.then(() => 
 			{
-				log.verbose("Completed pending update", { updateGuid });
+				log.verbose("Completed pending update", {
+					updateGuid, 
+				});
 				delete this.pendingUpdates[updateGuid];
 			})
 			.catch((error) => 
@@ -72,7 +76,9 @@ export class Broadcaster<
 				log.error(error);
 			});
 
-		log.verbose("Added pending update", { updateGuid });
+		log.verbose("Added pending update", {
+			updateGuid, 
+		});
 
 		// Return the pending update Promise
 		return this.pendingUpdates[updateGuid];

--- a/src/lib/Broadcast/_test/Broadcaster.test.ts
+++ b/src/lib/Broadcast/_test/Broadcaster.test.ts
@@ -1,5 +1,7 @@
 import chai, { expect } from "chai";
-import { beforeEach, describe, it } from "mocha";
+import {
+	beforeEach, describe, it, 
+} from "mocha";
 import chaiAsPromised from "chai-as-promised";
 
 import { BroadcasterObserver } from "@Broadcast/BroadcasterObserver";
@@ -60,7 +62,9 @@ describe("Broadcaster", () =>
 		{
 			const mockObserver = new MockObserver(() => {});
 			broadcaster.observe(mockObserver.update.bind(mockObserver));
-			const testData = { key: "value" };
+			const testData = {
+				key: "value", 
+			};
 
 			await broadcaster.broadcast(testData);
 			expect(mockObserver.dataReceived).to.deep.equal(testData);
@@ -68,7 +72,9 @@ describe("Broadcaster", () =>
 
 		it("completes broadcast with no observers without error", async () => 
 		{
-			const broadcastPromise = broadcaster.broadcast({ key: "value" });
+			const broadcastPromise = broadcaster.broadcast({
+				key: "value", 
+			});
 			await expect(broadcastPromise).to.be.fulfilled;
 		});
 	});
@@ -80,7 +86,9 @@ describe("Broadcaster", () =>
 			const mockObserver = new MockObserver(() => {});
 			broadcaster.observe(mockObserver.update.bind(mockObserver));
 
-			const testData = { key: "value" };
+			const testData = {
+				key: "value", 
+			};
 			await broadcaster.broadcast(testData);
 
 			expect(mockObserver.dataReceived).to.deep.equal(testData);
@@ -93,7 +101,9 @@ describe("Broadcaster", () =>
 
 			destroy();
 
-			const testData = { key: "value" };
+			const testData = {
+				key: "value", 
+			};
 			await broadcaster.broadcast(testData);
 
 			expect(mockObserver.dataReceived).to.be.null; // Assuming initial value is null
@@ -113,7 +123,9 @@ describe("Broadcaster", () =>
 			Broadcaster.destroyAll(destroy1, destroy2);
 
 			// Attempt to broadcast data and verify that observers do not receive it
-			const testData = { key: "value" };
+			const testData = {
+				key: "value", 
+			};
 
 			broadcaster
 				.broadcast(testData)

--- a/src/lib/Broadcast/_test/BroadcasterObserver.test.ts
+++ b/src/lib/Broadcast/_test/BroadcasterObserver.test.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
-import { beforeEach, describe, it } from "mocha";
+import {
+	beforeEach, describe, it, 
+} from "mocha";
 import sinon from "sinon";
 
 import { BroadcasterObserver } from "@Broadcast/BroadcasterObserver";
@@ -24,7 +26,9 @@ describe("BroadcasterObserver", () =>
 
 	it("calls the callback with provided data asynchronously", async () => 
 	{
-		const testData = { key: "value" };
+		const testData = {
+			key: "value", 
+		};
 		await observer.update(testData);
 
 		sinon.assert.calledOnce(callback);

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/ChainableMutatorQueue.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/ChainableMutatorQueue.ts
@@ -104,10 +104,14 @@ export class ChainableMutatorQueue<
 	{
 		return () => 
 		{
-			log.debug(`[${selfPath}] Operation execution starting`, { args });
+			log.debug(`[${selfPath}] Operation execution starting`, {
+				args, 
+			});
 
 			const mutatorResult = mutator(...args);
-			log.debug(`[${selfPath}] Operation finished executing`, { args });
+			log.debug(`[${selfPath}] Operation finished executing`, {
+				args, 
+			});
 
 			if (mutatorResult === undefined || mutatorResult === null) 
 			{

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/ChainableMutatorSetBuilder.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/ChainableMutatorSetBuilder.ts
@@ -8,7 +8,9 @@ import type { SortaPromise } from "@Evolvers/Types/EvolverTypes";
 
 import type { MutatorDefs } from "../../Types/MutatorTypes";
 import { createChainingProxy } from "./proxy/chaining-proxy-manager";
-import { cement, frost, getSandboxChanges } from "theseus-sandbox";
+import {
+	cement, frost, getSandboxChanges, 
+} from "theseus-sandbox";
 import { isFrostProxy } from "theseus-sandbox";
 import { containsSandboxProxy } from "theseus-sandbox";
 /**

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/_test/ChainableMutatorQueue.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/_test/ChainableMutatorQueue.test.ts
@@ -25,7 +25,9 @@ describe("ChainableMutatorQueue", function ()
 	it("should process synchronous mutators in sequence", function () 
 	{
 		const paramNoun = "testArg";
-		let testData: {value: number} = { value: 1 };
+		let testData: {value: number} = {
+			value: 1, 
+		};
         type TData ={value: number};
 
         const setData = (data: any) => 
@@ -52,13 +54,17 @@ describe("ChainableMutatorQueue", function ()
         void queue.queueMutation("syncMutatorPath", syncMutator, [testData, 1]);
         void queue.queueMutation("syncMutatorPath", syncMutator, [testData, 2]);
 
-        expect(testData).to.deep.equal({ value: 4 });
+        expect(testData).to.deep.equal({
+        	value: 4, 
+        });
 	});
 
 	it("should handle asynchronous mutators correctly", async function () 
 	{
 		const paramNoun = "testArg";
-		let testData: {value: number} = { value: 1 };
+		let testData: {value: number} = {
+			value: 1, 
+		};
         type TData ={value: number};
 
         const setData = (data: any) => 
@@ -93,14 +99,20 @@ describe("ChainableMutatorQueue", function ()
 
         const result = await q;
 
-        expect(result).to.deep.equal({ value: 4 });
+        expect(result).to.deep.equal({
+        	value: 4, 
+        });
 	});
 
 	it("should log an error if a mutator returns undefined", function () 
 	{
 		const paramNoun = "undefinedReturnArg" as string;
 		const setData = sinon.stub();
-		const getData = sinon.stub().returns({ [paramNoun]: { value: 0 } });
+		const getData = sinon.stub().returns({
+			[paramNoun]: {
+				value: 0, 
+			}, 
+		});
 		const undefinedMutator = () => undefined;
 
 		const queue = ChainableMutatorQueue.create({
@@ -118,7 +130,11 @@ describe("ChainableMutatorQueue", function ()
 	{
 		const paramNoun = "undefinedReturnArg" as string;
 		const setData = sinon.stub();
-		const getData = sinon.stub().returns({ [paramNoun]: { value: 0 } });
+		const getData = sinon.stub().returns({
+			[paramNoun]: {
+				value: 0, 
+			}, 
+		});
 		const stringMutator = () => "not an object" as any;
 
 		const queue = ChainableMutatorQueue.create({
@@ -137,7 +153,9 @@ describe("ChainableMutatorQueue", function ()
 		type Data = {"undefinedReturn": number};
 		const paramNoun = "undefinedReturn";
 		const setData = sinon.stub();
-		const getData = sinon.stub().returns({ [paramNoun]: 0 });
+		const getData = sinon.stub().returns({
+			[paramNoun]: 0, 
+		});
 		const numberToStringMutator = async () => 
 		{
 		    return Promise.resolve("not a number") as unknown as Data;
@@ -169,7 +187,11 @@ describe("ChainableMutatorQueue", function ()
 	{
 		const paramNoun = "testArg";
 		const setData = sinon.stub();
-		const getData = sinon.stub().returns({ [paramNoun]: { value: 0 } });
+		const getData = sinon.stub().returns({
+			[paramNoun]: {
+				value: 0, 
+			}, 
+		});
 		const queue = ChainableMutatorQueue.create({
 			paramNoun,
 			getData: getData,

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/_test/ChainableMutatorSetBuilder.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/_test/ChainableMutatorSetBuilder.test.ts
@@ -48,7 +48,9 @@ describe("ChainableMutatorSet", function ()
 
 	beforeEach(function () 
 	{
-		testData = { value: 0 };
+		testData = {
+			value: 0, 
+		};
 		chainableMutatorSet = buildChainableMutatorSet(testData);
 	});
 
@@ -136,7 +138,9 @@ describe("ChainableMutatorSet", function ()
 
 	it("should allow multiple chains to execute in parallel without interference", async function () 
 	{
-		const anotherTestData = { value: 10 };
+		const anotherTestData = {
+			value: 10, 
+		};
 		const anotherChain = buildChainableMutatorSet(anotherTestData);
 
 		const results = await Promise.all([

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/_test/chaining-proxy-manager.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/_test/chaining-proxy-manager.test.ts
@@ -5,7 +5,9 @@ import { ChainableMutatorQueue } from "../../ChainableMutatorQueue";
 
 const makeMutatorQueue = () => 
 {
-	let dataReference = { value: 0 };
+	let dataReference = {
+		value: 0, 
+	};
 	return ChainableMutatorQueue.create({
 		paramNoun: "data",
 		setData: ({ data }) => 
@@ -16,7 +18,9 @@ const makeMutatorQueue = () =>
 			}
 			dataReference = data;
 		},
-		getData: () => ({ data: dataReference }),
+		getData: () => ({
+			data: dataReference, 
+		}),
 	});
 };
 
@@ -126,7 +130,11 @@ describe("createChainingProxy", function ()
 
 	it("should maintain the order of queued mutations", function () 
 	{
-		const dataOrig = { data: { a: 1 } };
+		const dataOrig = {
+			data: {
+				a: 1, 
+			}, 
+		};
 		const order: number[] = [];
 		const target = {
 			mutatorsForProxy: {
@@ -151,7 +159,11 @@ describe("createChainingProxy", function ()
 
 		proxy
 			.first(dataOrig)
-			.second({ data: { a: 1 } });
+			.second({
+				data: {
+					a: 1, 
+				}, 
+			});
 		expect(order).to.deep.equal([1, 2]);
 	});
 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/_test/proxy-actions.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/_test/proxy-actions.test.ts
@@ -38,7 +38,9 @@ describe("ProxyActions", function()
 	{
 		it("should call runTest with correct parameters and log the appropriate message when outcome is true", function() 
 		{
-			const params: ProxyActionMapParameters = { prop: "testProp1" } as any;
+			const params: ProxyActionMapParameters = {
+				prop: "testProp1", 
+			} as any;
 			const matchingRequestTypes = ProxyActionType.function;
             
 			const runTestStub = sinon.stub(mockProxyActions, "runTest").returns(true);
@@ -51,7 +53,9 @@ describe("ProxyActions", function()
 
 		it("should call runTest with correct parameters and not log any message when outcome is false", function() 
 		{
-			const params: ProxyActionMapParameters = { prop: "testProp2" } as any;
+			const params: ProxyActionMapParameters = {
+				prop: "testProp2", 
+			} as any;
 			const matchingRequestTypes = ProxyActionType.function;
             
 			const runTestStub = sinon.stub(mockProxyActions, "runTest").returns(false);

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/chain-helper.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/chain-helper.test.ts
@@ -10,7 +10,12 @@ describe("ChainHelperAction", function()
 	beforeEach(function() 
 	{
 		chainHelperAction = new ChainHelperAction();
-		params = { prop: "and", proxy: {} as any, proxyManager: null as any, target: null };
+		params = {
+			prop: "and",
+			proxy: {} as any,
+			proxyManager: null as any,
+			target: null, 
+		};
 	});
 
 	it("should return true for matched properties in runTest", function() 
@@ -28,7 +33,9 @@ describe("ChainHelperAction", function()
 
 	it("should return the proxy in process method", function() 
 	{
-		const proxy = { test: "proxy" };
+		const proxy = {
+			test: "proxy", 
+		};
 		params.proxy = proxy as any;
 		expect(chainHelperAction.process(params)).to.equal(proxy);
 	});

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/chain-termination.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/chain-termination.test.ts
@@ -16,8 +16,15 @@ describe("ChainTerminationAction", function()
 			proxy: {} as any, 
 			proxyManager: { 
 				onChainEnd: () => {}, 
-				queue: { asyncEncountered: false, queue: [] } as any, 
-				params: { target: { result: "resultValue" } } as any, 
+				queue: {
+					asyncEncountered: false,
+					queue: [], 
+				} as any, 
+				params: {
+					target: {
+						result: "resultValue", 
+					}, 
+				} as any, 
 			} as any, 
 		} as any;
 	});
@@ -39,7 +46,10 @@ describe("ChainTerminationAction", function()
 	{
 		const proxyManager = {
 			onChainEnd: sinon.spy(),
-			queue: { asyncEncountered: false, queue: [] },
+			queue: {
+				asyncEncountered: false,
+				queue: [], 
+			},
 			params: { 
 				target: {
 					 end: () => "resultValue", 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/function.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/function.test.ts
@@ -10,7 +10,11 @@ describe("FunctionAction", function()
 	beforeEach(function() 
 	{
 		functionAction = new FunctionAction();
-		params = { target: () => {}, prop: "apply", proxy: {} as any } as any;
+		params = {
+			target: () => {},
+			prop: "apply",
+			proxy: {} as any, 
+		} as any;
 	});
 
 	it("should return true for function type in runTest", function() 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/mutator.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/mutator.test.ts
@@ -10,7 +10,15 @@ describe("MutatorAction", function()
 	beforeEach(function() 
 	{
 		mutatorAction = new MutatorAction();
-		params = { target: { mutatorsForProxy: { mutate: () => {} } }, prop: "mutate", proxy: {} } as any;
+		params = {
+			target: {
+				mutatorsForProxy: {
+					mutate: () => {}, 
+				}, 
+			},
+			prop: "mutate",
+			proxy: {}, 
+		} as any;
 	});
 
 	it("should return true for mutation properties in runTest", function() 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/property.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/property.test.ts
@@ -11,7 +11,13 @@ describe("PropertyAction", function()
 	beforeEach(function() 
 	{
 		propertyAction = new PropertyAction();
-		params = { target: { prop1: "value1" }, prop: "prop1", proxy: {} } as any;
+		params = {
+			target: {
+				prop1: "value1", 
+			},
+			prop: "prop1",
+			proxy: {}, 
+		} as any;
 	});
 
 	it("should return true for existing properties in runTest", function() 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/to-json.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/to-json.test.ts
@@ -10,7 +10,13 @@ describe("ToJsonAction", function()
 	beforeEach(function() 
 	{
 		toJsonAction = new ToJsonAction();
-		params = { target: { prop: "value" }, prop: "toJSON", proxy: {} } as any;
+		params = {
+			target: {
+				prop: "value", 
+			},
+			prop: "toJSON",
+			proxy: {}, 
+		} as any;
 	});
 
 	it("should return true for toJSON property in runTest", function() 
@@ -21,6 +27,8 @@ describe("ToJsonAction", function()
 	it("should return serialized object in process", function() 
 	{
 		const result = toJsonAction.process(params);
-		expect(result()).to.deep.equal({ prop: "value" });
+		expect(result()).to.deep.equal({
+			prop: "value", 
+		});
 	});
 });

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/update-data.test.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/_test/tests/update-data.test.ts
@@ -10,7 +10,13 @@ describe("UpdateDataAction", function()
 	beforeEach(function() 
 	{
 		updateDataAction = new UpdateDataAction();
-		params = { target: { replaceData: "newData" }, prop: "setData", proxy: {} } as any;
+		params = {
+			target: {
+				replaceData: "newData", 
+			},
+			prop: "setData",
+			proxy: {}, 
+		} as any;
 	});
 
 	it("should return true for setData property in runTest", function() 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/chain-termination.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/chain-termination.ts
@@ -23,7 +23,9 @@ export class ChainTerminationAction extends ProxyActions
 		return propMatches;
 	}
 	
-	public process({ prop, proxyManager, proxy }: ProxyActionMapParameters) 
+	public process({
+		prop, proxyManager, proxy, 
+	}: ProxyActionMapParameters) 
 	{
 		const processReturnsProxy = this.matchAgainstProps.get(prop) ?? false;
 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/mutator.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/mutator.ts
@@ -21,7 +21,9 @@ export class MutatorAction extends ProxyActions
 		return this.handleMutatorCall(params);
 	}
 
-	private handleMutatorCall({ target, prop, proxyManager, proxy }: ProxyActionMapParameters) 
+	private handleMutatorCall({
+		target, prop, proxyManager, proxy, 
+	}: ProxyActionMapParameters) 
 	{
 		return (...args: any[]) => 
 		{

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/to-json.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/actions/to-json.ts
@@ -24,7 +24,9 @@ export class ToJsonAction extends ProxyActions
 		log.verbose("toJSON called");
 		return () => 
 		{
-			const copy = { ...target };
+			const copy = {
+				...target, 
+			};
 			delete copy.chainingProxy; // Remove the circular reference when serializing
 			return copy;
 		};

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/chaining-proxy-manager.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/chaining-proxy-manager.ts
@@ -81,7 +81,7 @@ export class ChainingProxyManager<TTarget extends ChainableMutatorSetBuilder<any
 			if (result instanceof Promise)
 			{
 				this.log.verbose("Result is a promise; skipping reset.", {
-					isFinalChainLink: this.isFinalChainLink,
+					isFinalChainLink: this.isFinalChainLink, 
 				});
 			}
 			else 
@@ -114,9 +114,21 @@ export class ChainingProxyManager<TTarget extends ChainableMutatorSetBuilder<any
 			return target[prop];
 		}
 
-		const requestType = ProxyActionMap.determineAction({ target, prop, proxy, proxyManager: this });
+		const requestType = ProxyActionMap.determineAction({
+			target,
+			prop,
+			proxy,
+			proxyManager: this,
+			queue: this.queue, 
+		});
 
-		const result = ProxyActionMap.process({ target, prop, proxy, proxyManager: this }, requestType);
+		const result = ProxyActionMap.process({
+			target,
+			prop,
+			proxy,
+			proxyManager: this,
+			queue: this.queue, 
+		}, requestType);
 
 		this.log.verbose(`[${prop}] Returning result`);
 
@@ -132,7 +144,7 @@ export class ChainingProxyManager<TTarget extends ChainableMutatorSetBuilder<any
 	public create(): TTarget 
 	{
 		const proxy: any = new Proxy(this.target as any, {
-			get: (target: any, rawProp: string | symbol) => this.getProperty(proxy, target, rawProp),
+			get: (target: any, rawProp: string | symbol) => this.getProperty(proxy, target, rawProp), 
 		});
 
 		return proxy;

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/proxy-action-map.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/proxy-action-map.ts
@@ -1,4 +1,5 @@
 import { getTheseusLogger } from "../../../../Shared";
+import type { ChainableMutatorQueue } from "../ChainableMutatorQueue";
 import { ChainHelperAction } from "./actions/chain-helper";
 import { ChainTerminationAction } from "./actions/chain-termination";
 import { FunctionAction } from "./actions/function";
@@ -17,7 +18,8 @@ export interface ProxyActionMapParameters
 	target: any, 
 	prop: string, 
 	proxyManager: ChainingProxyManager<any>,
-	proxy: ChainingProxyManager<any>
+	proxy: ChainingProxyManager<any>,
+	queue: ChainableMutatorQueue<any, any>
 }
 
 export class ProxyActionMap
@@ -48,7 +50,7 @@ export class ProxyActionMap
 
 	public static process(params: ProxyActionMapParameters, requestType: ProxyActionType)
 	{
-		const { prop, proxy } = params;
+		const { prop } = params;
 		let toReturn: any = undefined; // Initial value is undefined to indicate "not set"
 
 		this.actions.forEach((action) => 
@@ -72,7 +74,7 @@ export class ProxyActionMap
 		// If after checking all bits toReturn is still undefined, it means no valid action was matched.
 		if (typeof toReturn === "undefined") 
 		{
-			log.trace(`Property or action "${prop}" not found in target or not supported`, { prop, proxy });
+			log.trace(`Property or action "${prop}" not found in target or not supported`);
 			throw new Error(`Property or action "${prop}" not found in target or not supported`);
 		}
 

--- a/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/proxy-actions.ts
+++ b/src/lib/Evolvers/MutatorSets/ChainableMutatorSetBuilder/proxy/proxy-actions.ts
@@ -10,7 +10,7 @@ export enum ProxyActionType {
     property = 1 << 3, // 8
     chainTermination = 1 << 4, // 16
     chainHelper = 1 << 5, // 32
-    updateData = 1 << 6, // 64
+    updateData = 1 << 6, // 64,
 }
 
 const log = getTheseusLogger("proxy-actions");

--- a/src/lib/Evolvers/MutatorSets/MutatorSetBuilder/MutatorSetBuilder.ts
+++ b/src/lib/Evolvers/MutatorSets/MutatorSetBuilder/MutatorSetBuilder.ts
@@ -5,7 +5,9 @@ import getTheseusLogger from "@Shared/Log/get-theseus-logger";
 
 
 import type { GenericMutator, MutatorDefs } from "../../Types/MutatorTypes";
-import { cement, frost, isSandboxProxy, sandbox } from "theseus-sandbox";
+import {
+	cement, frost, isSandboxProxy, sandbox, 
+} from "theseus-sandbox";
 /**
  * Represents a set of mutators that can be applied to an evolver's data. It provides the infrastructure for
  * adding mutator functions to the evolver and executing these functions to mutate the evolver's state.
@@ -150,7 +152,9 @@ export class MutatorSetBuilder<
 				Theseus.incrementStackDepth(this.__theseusId);
 				const draft = isSandboxProxy(this.data[this.paramNoun]) 
 					? this.data 
-					: sandbox(this.data, { mode: "copy" });
+					: sandbox(this.data, {
+						mode: "copy", 
+					});
 				
 				let funcResult: SortaPromise<TData>;
 				try 
@@ -247,7 +251,9 @@ export class MutatorSetBuilder<
 		input: _TData,
 	): { [key in _TParamNoun]: _TData } 
 	{
-		return { [this.paramNoun]: input } as {
+		return {
+			[this.paramNoun]: input, 
+		} as {
             [key in _TParamNoun]: _TData;
         };
 	}

--- a/src/lib/Evolvers/MutatorSets/MutatorSetBuilder/_test/MutatorSetBuilder.test.ts
+++ b/src/lib/Evolvers/MutatorSets/MutatorSetBuilder/_test/MutatorSetBuilder.test.ts
@@ -7,7 +7,9 @@ describe("MutatorSetBuilder", function ()
     type TestData = { testProp: number };
     const paramNoun = "testProp";
 
-    let initialData: TestData = { testProp: 42 };
+    let initialData: TestData = {
+    	testProp: 42, 
+    };
     const makeBuilder = () =>
     	MutatorSetBuilder.create(initialData, paramNoun, {
     		increase: ({ testProp }, amount: number) => 
@@ -20,7 +22,9 @@ describe("MutatorSetBuilder", function ()
 
     beforeEach(function () 
     {
-    	initialData = { testProp: 42 };
+    	initialData = {
+    		testProp: 42, 
+    	};
     	builder = makeBuilder();
     });
 
@@ -28,13 +32,17 @@ describe("MutatorSetBuilder", function ()
     {
     	expect(builder)
     		.to.have.property("data")
-    		.that.deep.includes({ [paramNoun]: initialData });
+    		.that.deep.includes({
+    			[paramNoun]: initialData, 
+    		});
     });
 
     it("inputToObject transforms input data into structured format", function () 
     {
     	const structuredData = (builder as any)["inputToObject"](initialData);
-    	expect(structuredData).to.deep.equal({ [paramNoun]: initialData });
+    	expect(structuredData).to.deep.equal({
+    		[paramNoun]: initialData, 
+    	});
     });
 
     it("create method returns a new instance of MutatorSetBuilder", function () 
@@ -42,7 +50,9 @@ describe("MutatorSetBuilder", function ()
     	expect(builder).to.be.instanceOf(MutatorSetBuilder);
     	expect(builder)
     		.to.have.property("data")
-    		.that.deep.includes({ [paramNoun]: initialData });
+    		.that.deep.includes({
+    			[paramNoun]: initialData, 
+    		});
     });
 
     it("create method returns a new instance with mutators applied", function () 
@@ -56,6 +66,8 @@ describe("MutatorSetBuilder", function ()
     	// This will invoke the 'increase' function directly on the builder, demonstrating 
     	// its presence and functionality
     	const result = builder.increase(10);
-    	expect(result).to.deep.equal({ testProp: 52 });
+    	expect(result).to.deep.equal({
+    		testProp: 52, 
+    	});
     });
 });

--- a/src/lib/Evolvers/Types/ChainableTypes.ts
+++ b/src/lib/Evolvers/Types/ChainableTypes.ts
@@ -60,9 +60,9 @@ export type FinishChain<
     TParamNoun extends string,
     TMutators extends MutatorDefChild<TData, TParamNoun>,
     IsAsync extends AsyncTracker,
-> = IsAsync extends "async" 
+> = (IsAsync extends "async" 
 		? Record<"endAsync", () => Promise<TData>> 
-		: Record<"end", () => TData> &
+		: Record<"end", () => TData>) &
     Record<"lastly", ChainableMutators<TData, TParamNoun, TMutators, "final", IsAsync>>;
 
 type AsyncChainable<

--- a/src/lib/Evolvers/Types/EvolverComplexTypes.ts
+++ b/src/lib/Evolvers/Types/EvolverComplexTypes.ts
@@ -1,4 +1,6 @@
-import type { EvolveObject, EvolverInstance, MutateObject } from "@Evolvers/Types/EvolverTypes";
+import type {
+	EvolveObject, EvolverInstance, MutateObject, 
+} from "@Evolvers/Types/EvolverTypes";
 
 // Determines the mutators for a given evolver by returning the types of mutators available for the evolver's data.
 type MutatorsForEvolver<

--- a/src/lib/Evolvers/Types/EvolverComplexTypes.ts
+++ b/src/lib/Evolvers/Types/EvolverComplexTypes.ts
@@ -1,5 +1,5 @@
 import type {
-	EvolveObject, EvolverInstance, MutateObject, 
+	EvolveObject, EvolverInstance, MutateObject,
 } from "@Evolvers/Types/EvolverTypes";
 
 // Determines the mutators for a given evolver by returning the types of mutators available for the evolver's data.

--- a/src/lib/Evolvers/Types/MutatorTypes.ts
+++ b/src/lib/Evolvers/Types/MutatorTypes.ts
@@ -28,7 +28,7 @@ export type ParamNameData<TData extends object, TParamNoun extends string> = {
 
 /** Represents a collection of definitions for mutators applicable to a piece of evolver data. */
 export type MutatorDefs<TData extends object, TParamNoun extends string> = {
-    [key: string]: Mutator<TData, TParamNoun, SortaPromise<TData>>;
+    [key: string]: Mutator<TData, TParamNoun, SortaPromise<TData>>
 };
 
 /**

--- a/src/lib/Evolvers/Types/MutatorTypes.ts
+++ b/src/lib/Evolvers/Types/MutatorTypes.ts
@@ -28,16 +28,8 @@ export type ParamNameData<TData extends object, TParamNoun extends string> = {
 
 /** Represents a collection of definitions for mutators applicable to a piece of evolver data. */
 export type MutatorDefs<TData extends object, TParamNoun extends string> = {
-    [key: string]: MutatorDefChild<TData, TParamNoun>;
+    [key: string]: Mutator<TData, TParamNoun, SortaPromise<TData>>;
 };
-
-/**
- * A union type that can represent either a single mutator function or a nested collection of mutator
- * definitions. This allows for the recursive definition of mutators, supporting complex, nested mutations.
- */
-export type MutatorDefChild<TData extends object, TParamNoun extends string> =
-    | Mutator<TData, TParamNoun, SortaPromise<TData>>
-    | MutatorDefs<TData, TParamNoun>;
 
 /**
  * Constructs a dictionary type from a set of mutator definitions, converting each mutator function into a

--- a/src/lib/Evolvers/_test/Evolver.test.ts
+++ b/src/lib/Evolvers/_test/Evolver.test.ts
@@ -13,16 +13,24 @@ describe("Evolvers", () =>
     const testEvolver = Evolver.create("testEvolver")
     	.toEvolve<TestData>()
     	.withMutators({
-    		increment: ({ input }) => ({ value: input.value + 1 }),
-    		decrement: ({ input }) => ({ value: input.value - 1 }),
+    		increment: ({ input }) => ({
+    			value: input.value + 1, 
+    		}),
+    		decrement: ({ input }) => ({
+    			value: input.value - 1, 
+    		}),
     	});
 
     const preMutatorTestEvolver = Evolver.create("testEvolver").toEvolve<TestData>();
     type MutatorType = Parameters<(typeof preMutatorTestEvolver)["withMutators"]>[0];
 
     const testMutators = {
-    	increment: ({ input }) => ({ value: input.value + 1 }),
-    	decrement: ({ input }) => ({ value: input.value - 1 }),
+    	increment: ({ input }) => ({
+    		value: input.value + 1, 
+    	}),
+    	decrement: ({ input }) => ({
+    		value: input.value - 1, 
+    	}),
     } satisfies MutatorType;
 
     describe("Factory Method and Initialization", () => 
@@ -71,7 +79,9 @@ describe("Evolvers", () =>
         	{
         		// Assuming there's some form of validation on mutators, which there might not be.
         		// This is speculative and should be adapted to the actual error handling strategy of Evolver.
-        		const invalidMutators: any = { brokenMutator: null }; // Intentionally incorrect
+        		const invalidMutators: any = {
+        			brokenMutator: null, 
+        		}; // Intentionally incorrect
 
         		expect(() =>
         			Evolver.create("testEvolver").toEvolve<AnotherTestData>().withMutators(invalidMutators),
@@ -88,11 +98,15 @@ describe("Evolvers", () =>
         			.withMutators({
         				increment: ({ input }, by: number) =>
         				{ 
-        					return { value: input.value + by };
+        					return {
+        						value: input.value + by, 
+        					};
         				},
         			});
 
-        		const initialData = { value: 1 };
+        		const initialData = {
+        			value: 1, 
+        		};
 
         		const initialDataEvolver = testEvolver.evolve(initialData);
 
@@ -121,7 +135,9 @@ describe("Evolvers", () =>
         		const stringEvolver = Evolver.create("string")
         			.toEvolve<AnotherTestData>()
         			.withMutators({
-        				rename: ({ input }) => ({ name: `New ${input.name}` }),
+        				rename: ({ input }) => ({
+        					name: `New ${input.name}`, 
+        				}),
         			});
 
         		expect(stringEvolver).to.be.an.instanceof(Evolver);
@@ -199,14 +215,18 @@ describe("Evolvers", () =>
         				}),
         			});
 
-        		const resultA = await AsyncEvolver.evolve({ name: "1234" })
+        		const resultA = await AsyncEvolver.evolve({
+        			name: "1234", 
+        		})
         			.via.asyncMakeNameLowerCase()
         			.and.asyncMakeNameUpperCase()
         			.and.asyncReverseName()
         			.lastly.syncReplaceVowels();
         		expect(resultA.name).to.equal("4321");
 
-        		const resultB = await AsyncEvolver.evolve({ name: "test" })
+        		const resultB = await AsyncEvolver.evolve({
+        			name: "test", 
+        		})
         			.via.syncReplaceVowels()
         			.and.asyncMakeNameUpperCase()
         			.lastly.asyncReverseName();

--- a/src/lib/Evolvers/_test/EvolverComplex.test.ts
+++ b/src/lib/Evolvers/_test/EvolverComplex.test.ts
@@ -49,7 +49,9 @@ describe("EvolverComplex", () =>
 		it("should execute a single mutation correctly", () => 
 		{
 			// Execute step: Use the setup to perform mutations
-			const initialData = { count: 0 };
+			const initialData = {
+				count: 0, 
+			};
 			const mutationResult = IncrementEvolver.mutate(initialData).via.increment(5);
 
 			expect(mutationResult.count).to.equal(5);
@@ -57,7 +59,9 @@ describe("EvolverComplex", () =>
 
 		it("should execute chained mutations correctly", () => 
 		{
-			const initialData = { count: 10 };
+			const initialData = {
+				count: 10, 
+			};
 
 			// Chained execution: Demonstrates the use of the same setup for multiple operations
 			const evolvedResult = IncrementEvolver.evolve(initialData)

--- a/src/lib/Refineries/ForgeSets/ForgeSet.ts
+++ b/src/lib/Refineries/ForgeSets/ForgeSet.ts
@@ -77,7 +77,9 @@ export class ForgeSet<
      */
 	protected inputToObject<TData, TParamNoun extends string>(input: TData): { [key in TParamNoun]: TData } 
 	{
-		return { [this.paramNoun]: input } as {
+		return {
+			[this.paramNoun]: input, 
+		} as {
             [key in TParamNoun]: TData;
         };
 	}

--- a/src/lib/Refineries/Refinery.ts
+++ b/src/lib/Refineries/Refinery.ts
@@ -2,7 +2,9 @@
 import getTheseusLogger from "@Shared/Log/get-theseus-logger";
 import { ForgeSet } from "./ForgeSets/ForgeSet";
 import { normalizeRefineryName, type NormalizedRefineryName } from "./Util/normalizeRefineryName";
-import type { ForgeDefs, RefineObject, RefineryDefinition as RefineryOptions } from "./Types/RefineryTypes";
+import type {
+	ForgeDefs, RefineObject, RefineryDefinition as RefineryOptions, 
+} from "./Types/RefineryTypes";
 import { sandbox } from "theseus-sandbox";
 
 const log = getTheseusLogger("Refinery");
@@ -75,7 +77,9 @@ export class Refinery<
      */
 	public refine(input: TData) 
 	{
-		const clone = sandbox(input, { mode: "copy" });
+		const clone = sandbox(input, {
+			mode: "copy", 
+		});
 
 		// Create the actions which will be available when `for()` is called.
 		const forgeSet = ForgeSet.create<TData, TParamNoun, TForges>(

--- a/src/lib/Refineries/Types/RefineryTypes.ts
+++ b/src/lib/Refineries/Types/RefineryTypes.ts
@@ -35,7 +35,7 @@ export type ForgeDefs<TData extends object, TParamNoun extends string> = {
 export type ExposeForges<
     TData extends object,
     TParamNoun extends string,
-    TForges extends ForgeDefChild<TData, TParamNoun>,
+    TForges extends ForgeDefs<TData, TParamNoun>,
 > = {
     // Iterate over each key in TMutators to create a chainable method
     [K in keyof TForges]: TForges[K] extends (...args: any) => any ?
@@ -43,7 +43,7 @@ export type ExposeForges<
             // Return another function which creates the chain
             (...args: Parameters<TForges[K]>) => ReturnType<TForges[K]>
         >
-    : TForges[K] extends ForgeDefChild<TData, TParamNoun> ? ExposeForges<TData, TParamNoun, TForges[K]>
+    : TForges[K] extends ForgeDefs<TData, TParamNoun> ? ExposeForges<TData, TParamNoun, TForges[K]>
     : never;
 };
 

--- a/src/lib/Refineries/Types/RefineryTypes.ts
+++ b/src/lib/Refineries/Types/RefineryTypes.ts
@@ -21,18 +21,8 @@ export type ForgeDict<TDict extends Record<string, () => any>> = {
  * @template TParamNoun The name of the parameter representing the data
  */
 export type ForgeDefs<TData extends object, TParamNoun extends string> = {
-    [key: string]: ForgeDefChild<TData, TParamNoun>;
+    [key: string]: Forge<TData, TParamNoun>;
 };
-
-/**
- * Represents either a single forge function or a nested collection of forge definitions.
- *
- * @template TData The type of data being refined.
- * @template TParamNoun The name of the parameter representing the data
- */
-export type ForgeDefChild<TData extends object, TParamNoun extends string> =
-    | Forge<TData, TParamNoun>
-    | ForgeDefs<TData, TParamNoun>;
 
 /**
  * Exposes forge functions from a set to be used in data refinement processes. This type dynamically creates a

--- a/src/lib/Refineries/_test/Refinery.test.ts
+++ b/src/lib/Refineries/_test/Refinery.test.ts
@@ -35,7 +35,9 @@ describe("Refinery Base", function ()
     				field: testData.field.toUpperCase(),
     			}),
     		});
-    	const testData: TestData = { field: "test" };
+    	const testData: TestData = {
+    		field: "test", 
+    	};
     	const result = testRefinery.refine(testData).forge1(); // Assuming `applyForges` is a method to apply forges
     	expect(result.field).to.equal("TEST");
     });
@@ -50,7 +52,9 @@ describe("Refinery Base", function ()
     				field: testData.field.toUpperCase(),
     			}),
     		});
-    	const testData: TestData = { field: "test" };
+    	const testData: TestData = {
+    		field: "test", 
+    	};
     	const result = testRefinery.refine(testData).forge1();
     	expect(result.field).to.equal("TEST");
     });

--- a/src/lib/Refineries/_test/RefineryComplex.test.ts
+++ b/src/lib/Refineries/_test/RefineryComplex.test.ts
@@ -52,7 +52,10 @@ describe("RefineryComplex", function ()
     		createMockIncrementCountRefinery(),
     	);
 
-    	const testData: TestData = { field: "test", count: 1 };
+    	const testData: TestData = {
+    		field: "test",
+    		count: 1, 
+    	};
     	const { mockIncrementCount, mockUpperCase } = refineryComplex.refine(testData);
     	const resultAfterUppercase = mockUpperCase.makeUppercase();
     	const resultAfterIncrement = mockIncrementCount.incrementCount();
@@ -67,9 +70,14 @@ describe("RefineryComplex", function ()
     		createMockUpperCaseRefinery(),
     	);
 
-    	const testData: TestData = { field: "test", count: 1 };
+    	const testData: TestData = {
+    		field: "test",
+    		count: 1, 
+    	};
     	const { mockUpperCase } = refineryComplex.refine(testData);
-    	const resultBefore = { ...testData };
+    	const resultBefore = {
+    		...testData, 
+    	};
     	mockUpperCase.makeUppercase();
 
     	// Ensuring the original testData is not modified by the refinery process
@@ -82,7 +90,10 @@ describe("RefineryComplex", function ()
     		createMockUpperCaseRefinery(),
     	);
 
-    	const testData: TestData = { field: "", count: 0 };
+    	const testData: TestData = {
+    		field: "",
+    		count: 0, 
+    	};
     	const { mockUpperCase } = refineryComplex.refine(testData);
     	const result = mockUpperCase.makeUppercase();
 
@@ -96,7 +107,10 @@ describe("RefineryComplex", function ()
     		createMockIncrementCountRefinery(),
     	);
 
-    	const testData: TestData = { field: "sequence", count: 0 };
+    	const testData: TestData = {
+    		field: "sequence",
+    		count: 0, 
+    	};
     	const { mockIncrementCount, mockUpperCase } = refineryComplex.refine(testData);
     	const resultAfterUppercase = mockUpperCase.makeUppercase();
     	const resultAfterIncrement = mockIncrementCount.incrementCount();
@@ -113,8 +127,13 @@ describe("RefineryComplex", function ()
     		createMockIncrementCountRefinery(),
     	);
 
-    	const testData: TestData = { field: "immutable", count: 1 };
-    	const originalTestData = { ...testData };
+    	const testData: TestData = {
+    		field: "immutable",
+    		count: 1, 
+    	};
+    	const originalTestData = {
+    		...testData, 
+    	};
     	const funcs = refineryComplex.refine(testData);
     	const { mockIncrementCount, mockUpperCase } = funcs;
     	mockUpperCase.makeUppercase();

--- a/src/lib/Shared/Log/_test/stringifier.test.ts
+++ b/src/lib/Shared/Log/_test/stringifier.test.ts
@@ -6,12 +6,18 @@ describe("stringifier", function()
 	it("should serialize primitive values correctly", function() 
 	{
 		// Adjust for pretty-printed output
-		expect(stringifier({ value: "test" })).to.equal(JSON.stringify({ value: "test" }, null, 2));
+		expect(stringifier({
+			value: "test", 
+		})).to.equal(JSON.stringify({
+			value: "test", 
+		}, null, 2));
 	});
 
 	it("should apply custom formatting to arrays of primitives", function() 
 	{
-		const obj = { key: [1, "string", true] };
+		const obj = {
+			key: [1, "string", true], 
+		};
 		// Understanding that custom formatting may not be as initially expected
 		// Check if output is valid JSON and parse it to verify the structure
 		const result = stringifier(obj);

--- a/src/lib/Shared/Log/get-theseus-logger.ts
+++ b/src/lib/Shared/Log/get-theseus-logger.ts
@@ -13,7 +13,9 @@ const rootLogger = winston.createLogger({
 });
 
 export type TheseusLogParams = Parameters<typeof winston.createLogger>[0];
-const buildLogger = (label: string) => rootLogger.child({ label });
+const buildLogger = (label: string) => rootLogger.child({
+	label, 
+});
 
 /**
  * Returns a logger with the given name.

--- a/src/lib/Shared/Log/winston-config-builder.ts
+++ b/src/lib/Shared/Log/winston-config-builder.ts
@@ -6,7 +6,9 @@ import { theseusArgs } from "./theseus-args";
 import { DEFAULT_LOG_LEVEL, logLevels } from "./log-levels";
 
 const { format, addColors } = winston;
-const { combine, colorize, timestamp, printf, errors, splat, prettyPrint, json } = format;
+const {
+	combine, colorize, timestamp, printf, errors, splat, prettyPrint, json, 
+} = format;
 
 const logFilter = theseusArgs["theseus-log-filter"];
 
@@ -27,16 +29,27 @@ const filterLogs = format((info) =>
 
 export const theseusLogFormat = () =>
 	combine(
-		errors({ stack: true }),
-		colorize({ all: true }),
+		errors({
+			stack: true, 
+		}),
+		colorize({
+			all: true, 
+		}),
 		splat(),
-		json({ space: 2, circularValue: undefined }),
+		json({
+			space: 2,
+			circularValue: undefined, 
+		}),
 		prettyPrint(),
-		timestamp({ format: "HH:mm:ss:SS" }),
+		timestamp({
+			format: "HH:mm:ss:SS", 
+		}),
 		filterLogs(),
 		printf((info) => 
 		{
-			const { label, level, timestamp, message, ...args } = info;
+			const {
+				label, level, timestamp, message, ...args 
+			} = info;
 			const argsAsString = stringifier(args)
 				.split("\n")
 				.map((line) => `|  ${line}`)

--- a/src/lib/Shared/Object/_test/TypedObject.test.ts
+++ b/src/lib/Shared/Object/_test/TypedObject.test.ts
@@ -6,7 +6,11 @@ describe("TypedObject", () =>
 {
 	it("Ensures .keys matches default Object.keys", () => 
 	{
-		const baseObj = { 1: 2, 3: 4, 5: 6 };
+		const baseObj = {
+			1: 2,
+			3: 4,
+			5: 6, 
+		};
 
 		expect(Object.keys(baseObj)).to.deep.equal(TypedObject.keys(baseObj));
 	});


### PR DESCRIPTION
Nested mutators don't work well with the proxy system which is used for chaining, and they are unnecessary as it is easy to create another private evolver in the same file

BREAKING CHANGE: Cannot nest mutators or forges