### PR TITLE
fix(sandbox): fix cement for nested sandboxes, enhance isSandboxProxy…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
             "request": "launch",
             "name": "Run Sandbox Tests",
             "runtimeExecutable": "pnpm",
-            "runtimeArgs": ["--prefix","./packages/sandbox", "test", "--", "--grep", "\"should allow defrosting of a frosted object\""],
+            "runtimeArgs": ["--prefix","./packages/sandbox", "test", "--timeout", "60000", "--", "--grep", "\"should return the original object if it is a sandbox proxy\""],
             "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}",
             "outputCapture": "std"

--- a/packages/sandbox/_test/type-tests.test.ts
+++ b/packages/sandbox/_test/type-tests.test.ts
@@ -79,7 +79,11 @@ describe("Integration type tests", function()
 		expect(() => JSON.stringify(cemented)).not.to.throw();
 		expect(isSbProxy).to.deep.equal({
 			root: false,
-			properties: false,
+			properties: {
+				all: false,
+				any: true,
+				elligible: true,
+			},
 		});
 	};
 

--- a/packages/sandbox/lib/cement/_test/cement.test.ts
+++ b/packages/sandbox/lib/cement/_test/cement.test.ts
@@ -15,7 +15,8 @@ describe("cement", function()
 			key2: "newValue2",
 			key3: "value3", 
 		};
-		const proxy = { 
+		const proxy = {
+			...original,
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
@@ -45,6 +46,7 @@ describe("cement", function()
 			key3: "value3", 
 		};
 		const proxy = { 
+			...original,
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
@@ -80,6 +82,7 @@ describe("cement", function()
 			}, 
 		};
 		const proxy = { 
+			...original,
 			[CONSTANTS.SANDBOX_SYMBOL]: { 
 				original, 
 				changes, 
@@ -130,5 +133,27 @@ describe("cement", function()
 				}
 			}
 		};
+	});
+
+	it("should cement nested objects even if the root object is not a sandbox", function()
+	{
+		const original = {
+			key1: "value1",
+			key2: {
+				key3: "value3", 
+			}, 
+		};
+		const sb = sandbox(original.key2);
+		sb.key3 = "replacement";
+		original.key2 = sb;
+		const result = cement(original);
+		expect(result).to.deep.equal({
+			key1: "value1",
+			key2: {
+				key3: "replacement", 
+			}, 
+		});
+
+		expect(isSandboxProxy(result)).to.be.false;
 	});
 });

--- a/packages/sandbox/lib/reject/_test/reject.test.ts
+++ b/packages/sandbox/lib/reject/_test/reject.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import { reject } from "../reject";
 import { CONSTANTS } from "../../constants";
-import { isSandboxProxy } from "../../sandbox/is-sandbox-proxy";
 
 describe("reject", function() 
 {
@@ -11,13 +10,12 @@ describe("reject", function()
 			key: "value", 
 		};
 		const proxy = {
+			...original,
 			[CONSTANTS.SANDBOX_SYMBOL]: {
 				original, 
 			}, 
 		};
     
-		// Mock the isSandboxProxy function to return true
-		isSandboxProxy(proxy);
 		expect(reject(proxy)).to.equal(original);
 	});
 
@@ -26,8 +24,7 @@ describe("reject", function()
 		const obj = {
 			key: "value", 
 		};
-		// Mock the isSandboxProxy function to return false
-		isSandboxProxy(obj);
+		
 		expect(reject(obj)).to.equal(obj);
 	});
 });

--- a/packages/sandbox/lib/sandbox/_test/get-sandbox-changes.test.ts
+++ b/packages/sandbox/lib/sandbox/_test/get-sandbox-changes.test.ts
@@ -10,6 +10,7 @@ describe("getSandboxChanges", function()
 			some: "changes", 
 		};
 		const sandboxProxy = {
+			some: "unchanged",
 			[CONSTANTS.SANDBOX_SYMBOL]: {
 				changes,
 			},

--- a/src/lib/Shared/Log/_test/stringifier.test.ts
+++ b/src/lib/Shared/Log/_test/stringifier.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { stringifier } from "../stringifier";
+import { sandbox } from "theseus-sandbox";
 
 describe("stringifier", function() 
 {
@@ -38,5 +39,26 @@ describe("stringifier", function()
 		expect(result).to.be.a("string");
 		const parsedResult = JSON.parse(result);
 		expect(parsedResult).to.have.nested.property("outer.inner").that.is.an("array");
+	});
+
+	it("shuld handle dates", function()
+	{
+		const obj = {
+			date: new Date(),
+		};
+		const result = stringifier(obj);
+		expect(result).to.be.a("string");
+		const parsedResult = JSON.parse(result);
+		expect(parsedResult).to.have.property("date").that.is.a("string");
+	});
+
+	it("shuld handle dates in a sandbox", function()
+	{
+		const obj = {
+			date: new Date(),
+		};
+		const sb = sandbox(obj);
+		const result = stringifier(sb);
+		expect(result).to.be.a("string");
 	});
 });


### PR DESCRIPTION
… to account for inelligible properties

Cement was failing if the root object wasn't a sandbox, even if a nested object was. This was partly becuase the isSandboxProxy function was failing to appropriately detect nested Sandboxes if they were empty objects or otherwise were potentially elligible to BE sandboxes, but weren't detectable (e.g. an object with no keys). In that situation, although the object is elligible to be a sandbox, and contains no sandboxes, it still returned true because we didn't account for that situation.